### PR TITLE
Bugfix: Provide source language to m2m100 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This library currently supports three NMT models:
 - [m2m100_418M](https://huggingface.co/facebook/m2m100_418M) and [m2m100_1.2B](https://huggingface.co/facebook/m2m100_1.2B) by [Fan et al. (2021)](https://www.jmlr.org/papers/volume22/20-1307/)
 - [Prism](https://github.com/thompsonb/prism) by [Thompson and Post (2020)](https://aclanthology.org/2020.emnlp-main.8/)
 
-By default, the leanest model (m2m100_418M) is loaded. The main results in the paper are based on the Prism model.
+By default, the leanest model (m2m100_418M) is loaded. The main results in the paper are based on the Prism model, which has some extra requirements (see "Installation"), but is recommended due to its higher accuracy.
 
 ```python
 scorer = NMTScorer("m2m100_418M", device=None)  # default
@@ -118,7 +118,7 @@ The NMT models also provide a direct interface for translating and scoring.
 ```python
 from nmtscore.models import load_translation_model
 
-model = load_translation_model("m2m100_418M")
+model = load_translation_model("prism")
 
 model.translate("de", ["This is a test."])
 # ["Das ist ein Test."]

--- a/experiments/metrics/benchmark_metrics.py
+++ b/experiments/metrics/benchmark_metrics.py
@@ -101,6 +101,8 @@ def get_paraphrase_metrics(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood",
             metric_names=["nmtscore-cross"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("prism", device=device),
                 both_directions=True,
                 translate_kwargs=NMT_TRANSLATE_KWARGS,
@@ -166,6 +168,8 @@ def get_nlg_evaluation_metrics(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood",
             metric_names=["nmtscore-cross", "nmtscore-cross-hyp|ref", "nmtscore-cross-ref|hyp"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("prism", device=device),
                 both_directions=True,
                 translate_kwargs=NMT_TRANSLATE_KWARGS,
@@ -208,6 +212,8 @@ def get_paraphrase_metrics_m2m100(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood (m2m100_418M)",
             metric_names=["nmtscore-cross"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("m2m100_418M", device=device),
                 both_directions=True,
                 translate_kwargs={**NMT_TRANSLATE_KWARGS, **{"batch_size": batch_size}},
@@ -242,6 +248,8 @@ def get_paraphrase_metrics_m2m100(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood (m2m100_1.2B)",
             metric_names=["nmtscore-cross"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("m2m100_1.2B", device=device),
                 both_directions=True,
                 translate_kwargs={**NMT_TRANSLATE_KWARGS, **{"batch_size": batch_size}},
@@ -285,6 +293,8 @@ def get_normalization_ablation_metrics(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood (normalized)",
             metric_names=["nmtscore-cross"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("prism", device=device),
                 normalize=True,
                 both_directions=True,
@@ -322,6 +332,8 @@ def get_normalization_ablation_metrics(device=None) -> List[BenchmarkMetric]:
             title="Translation_Cross-Likelihood (unnormalized)",
             metric_names=["nmtscore-cross"],
             load_func=lambda a_lang, b_lang, device=device: CrossLikelihoodNMTScoreMetric(
+                a_lang,
+                b_lang,
                 scorer=NMTScorer("prism", device=device),
                 normalize=False,
                 both_directions=True,

--- a/experiments/metrics/nmtscore_metrics.py
+++ b/experiments/metrics/nmtscore_metrics.py
@@ -12,11 +12,15 @@ from nmtscore import NMTScorer
 class NMTScoreMetric(ReferenceBasedMetric):
 
     def __init__(self,
+                 summaries_lang: Optional[str] = None,
+                 references_lang: Optional[str] = None,
                  scorer: Union[NMTScorer, str] = "m2m100_418M",
                  normalize: bool = True,
                  both_directions: bool = True,
                  ):
         super().__init__()
+        self.summaries_lang = summaries_lang
+        self.references_lang = references_lang
         if isinstance(scorer, str):
             self.scorer = NMTScorer(scorer)
         else:
@@ -108,9 +112,7 @@ class DirectNMTScoreMetric(NMTScoreMetric):
                  ):
         if both_directions:
             assert references_lang is not None
-        super().__init__(scorer, normalize, both_directions)
-        self.summaries_lang = summaries_lang
-        self.references_lang = references_lang
+        super().__init__(summaries_lang, references_lang, scorer, normalize, both_directions)
         self.score_kwargs = score_kwargs
 
     @property
@@ -156,9 +158,7 @@ class PivotNMTScoreMetric(NMTScoreMetric):
                  ):
         if both_directions:
             assert references_lang is not None
-        super().__init__(scorer, normalize, both_directions)
-        self.summaries_lang = summaries_lang
-        self.references_lang = references_lang
+        super().__init__(summaries_lang, references_lang, scorer, normalize, both_directions)
         self.pivot_lang = pivot_lang
         self.translate_kwargs = translate_kwargs
         self.score_kwargs = score_kwargs
@@ -200,6 +200,8 @@ class CrossLikelihoodNMTScoreMetric(NMTScoreMetric):
     name = "nmtscore-cross"
 
     def __init__(self,
+                 summaries_lang: Optional[str] = None,
+                 references_lang: Optional[str] = None,
                  tgt_lang: str = "en",
                  scorer: Union[NMTScorer, str] = "m2m100_418M",
                  normalize: bool = True,
@@ -207,7 +209,7 @@ class CrossLikelihoodNMTScoreMetric(NMTScoreMetric):
                  translate_kwargs: dict = None,
                  score_kwargs: dict = None,
                  ):
-        super().__init__(scorer, normalize, both_directions)
+        super().__init__(summaries_lang, references_lang, scorer, normalize, both_directions)
         self.tgt_lang = tgt_lang
         self.translate_kwargs = translate_kwargs
         self.score_kwargs = score_kwargs
@@ -221,6 +223,8 @@ class CrossLikelihoodNMTScoreMetric(NMTScoreMetric):
         return self.scorer.score_cross_likelihood(
             summaries,
             references,
+            self.summaries_lang,
+            self.references_lang,
             tgt_lang=self.tgt_lang,
             normalize=self.normalize,
             both_directions=False,
@@ -232,6 +236,8 @@ class CrossLikelihoodNMTScoreMetric(NMTScoreMetric):
         return self.scorer.score_cross_likelihood(
             references,
             summaries,
+            self.references_lang,
+            self.summaries_lang,
             tgt_lang=self.tgt_lang,
             normalize=self.normalize,
             both_directions=False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 
 [options.extras_require]
 prism =
-    fairseq
+    fairseq<=0.10.0
 
 [options.packages.find]
 where = src

--- a/src/nmtscore/models/m2m100.py
+++ b/src/nmtscore/models/m2m100.py
@@ -34,6 +34,14 @@ class M2M100Model(TranslationModel):
     def __str__(self):
         return self.model_name_or_path
 
+    @property
+    def requires_src_lang(self) -> bool:
+        return True
+
+    def _set_src_lang(self, src_lang: str):
+        self.src_lang = src_lang
+        self.tokenizer.src_lang = src_lang
+
     def _set_tgt_lang(self, tgt_lang: str):
         self.tgt_lang = tgt_lang
         self.tokenizer.tgt_lang = tgt_lang

--- a/src/nmtscore/models/prism.py
+++ b/src/nmtscore/models/prism.py
@@ -49,6 +49,10 @@ class PrismModel(TranslationModel):
     def __str__(self):
         return "prism"
 
+    @property
+    def requires_src_lang(self) -> bool:
+        return False
+
     def _set_tgt_lang(self, tgt_lang: str):
         assert tgt_lang in self.supported_languages
         self.tgt_lang = tgt_lang

--- a/src/nmtscore/scorer.py
+++ b/src/nmtscore/scorer.py
@@ -81,7 +81,7 @@ class NMTScorer:
             **(score_kwargs or {}),
         )
         if normalize:
-            self_scores = self.score_direct(a, a, a_lang, b_lang=a_lang, normalize=False, both_directions=False, score_kwargs=score_kwargs)
+            self_scores = self.score_direct(a, a, a_lang, a_lang, normalize=False, both_directions=False, score_kwargs=score_kwargs)
             scores = np.array(scores) / np.array(self_scores)
         if both_directions:
             reverse_scores = self.score_direct(b, a, b_lang, a_lang, normalize=normalize, both_directions=False, score_kwargs=score_kwargs)
@@ -141,7 +141,7 @@ class NMTScorer:
             **(score_kwargs or {}),
         )
         if normalize:
-            self_scores = self.score_pivot(a, a, a_lang, b_lang=a_lang, pivot_lang=pivot_lang, normalize=False, both_directions=False,
+            self_scores = self.score_pivot(a, a, a_lang, a_lang, pivot_lang=pivot_lang, normalize=False, both_directions=False,
                                               translate_kwargs=translate_kwargs, score_kwargs=score_kwargs)
             scores = np.array(scores) / np.array(self_scores)
         if both_directions:
@@ -220,7 +220,7 @@ class NMTScorer:
                 )
             scores = np.array(scores) / np.array(translation_scores)
         if both_directions:
-            reverse_scores = self.score_cross_likelihood(b, a, tgt_lang, a_lang=b_lang, b_lang=a_lang,
+            reverse_scores = self.score_cross_likelihood(b, a, b_lang, a_lang, tgt_lang=tgt_lang,
                                                     normalize=normalize, both_directions=False,
                                                     translate_kwargs=translate_kwargs, score_kwargs=score_kwargs)
             scores = self._average_scores(scores, reverse_scores)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,6 +14,10 @@ class CopyTranslationModel(TranslationModel):
     def __str__(self):
         return "copy-translation-model"
 
+    @property
+    def requires_src_lang(self) -> bool:
+        return False
+
     def _set_tgt_lang(self, tgt_lang: str):
         pass
 

--- a/tests/test_nmt_models.py
+++ b/tests/test_nmt_models.py
@@ -12,13 +12,13 @@ class NMTModelTestCase(TestCase):
         raise NotImplementedError
 
     def test_translate(self):
-        self.assertIn(self.model.translate("de", "This is a test."), {
+        self.assertIn(self.model.translate("de", "This is a test.", src_lang="en"), {
             "Dies ist ein Test.",
             "Das ist ein Test.",
         })
 
     def test_translate_score(self):
-        translation, score = self.model.translate("de", "This is a test.", return_score=True)
+        translation, score = self.model.translate("de", "This is a test.", return_score=True, src_lang="en")
         self.assertIn(translation, {
             "Dies ist ein Test.",
             "Das ist ein Test.",
@@ -27,10 +27,10 @@ class NMTModelTestCase(TestCase):
             return
         self.assertGreaterEqual(score, 0)
         self.assertLessEqual(score, 1)
-        self.assertAlmostEqual(score, self.model.score("de", "This is a test.", translation), places=5)
+        self.assertAlmostEqual(score, self.model.score("de", "This is a test.", translation, src_lang="en"), places=5)
 
     def test_translate_batched(self):
-        translations = self.model.translate("de", 8 * ["This is a test."])
+        translations = self.model.translate("de", 8 * ["This is a test."], src_lang="en")
         self.assertEqual(8, len(translations))
         self.assertEqual(1, len(set(translations)))
         self.assertIn(translations[0], {
@@ -41,6 +41,7 @@ class NMTModelTestCase(TestCase):
     def test_score(self):
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(2 * ["This is a test."]),
             hypothesis_sentences=(["Dies ist ein Test.", "Diese Übersetzung ist komplett falsch."]),
         )
@@ -48,12 +49,14 @@ class NMTModelTestCase(TestCase):
         self.assertIsInstance(scores[1], float)
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(2 * ["This is a test."]),
             hypothesis_sentences=(["Diese Übersetzung ist komplett falsch.", "Dies ist ein Test."]),
         )
         self.assertLess(scores[0], scores[1])
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(2 * ["This is a test."]),
             hypothesis_sentences=(2 * ["Dies ist ein Test."]),
         )
@@ -62,6 +65,7 @@ class NMTModelTestCase(TestCase):
     def test_score_batched(self):
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(4 * ["This is a test."]),
             hypothesis_sentences=(["Diese Übersetzung ist komplett falsch", "Dies ist ein Test.", "Dies ist ein Test.", "Dies ist ein Test."]),
             batch_size=2,
@@ -72,6 +76,7 @@ class NMTModelTestCase(TestCase):
 
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(["This is a test.", "A translation that is completely wrong.", "This is a test.", "This is a test."]),
             hypothesis_sentences=(4 * ["Dies ist ein Test."]),
             batch_size=2,
@@ -82,6 +87,7 @@ class NMTModelTestCase(TestCase):
 
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(4 * ["This is a test."]),
             hypothesis_sentences=(["Dies ist ein Test.", "Dies ist ein Test.", ".", "Dies ist ein Test."]),
             batch_size=2,
@@ -92,6 +98,7 @@ class NMTModelTestCase(TestCase):
 
         scores = self.model.score(
             "de",
+            src_lang = "en",
             source_sentences=(["This is a test.", "This is a test.", "This is a test.", "A translation that is completely wrong."]),
             hypothesis_sentences=(4 * ["Dies ist ein Test."]),
             batch_size=2,
@@ -101,10 +108,10 @@ class NMTModelTestCase(TestCase):
         self.assertLess(scores[3], scores[0])
 
     def test_translate_long_input(self):
-        self.model.translate("de", 100 * "This is a test. ")
+        self.model.translate("de", 100 * "This is a test. ", src_lang="en")
 
     def test_score_long_input(self):
-        self.model.score("de", 100 * "This is a test. ", 100 * "Dies ist ein Test. ")
+        self.model.score("de", 100 * "This is a test. ", 100 * "Dies ist ein Test. ", src_lang="en")
 
 
 class SmallM2M100TestCase(NMTModelTestCase):

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -78,11 +78,11 @@ class ReadmeTestCase(TestCase):
         a = "This is a sentence."
         b = "This is another sentence."
         score = scorer.score(a, b, print_signature=True)
-        self.assertIn("NMTScore-cross|tgt-lang:en|model:facebook/m2m100_418M|normalized|both-directions", mock_stdout.getvalue())
+        self.assertIn("NMTScore-cross|tgt-lang:en|a-lang:en|b-lang:en|model:facebook/m2m100_418M|normalized|both-directions", mock_stdout.getvalue())
 
     def test_nmt_models(self):
         model = load_translation_model("m2m100_418M")
-        translations = model.translate("de", ["This is a test."])
+        translations = model.translate("de", ["This is a test."], src_lang="en")
         self.assertEqual(["Das ist ein Test."], translations)
-        scores = model.score("de", ["This is a test."], ["Das ist ein Test."])
+        scores = model.score("de", ["This is a test."], ["Das ist ein Test."], src_lang="en")
         self.assertAlmostEqual(0.5148844122886658, scores[0], places=4)


### PR DESCRIPTION
Ensure that m2m100 models are provided with the source language when translating or scoring. Currently, only the target language is provided and the model silently defaults to English as the source language.

The library remains backwards-compatible but a warning is now raised if m2m100 is used without specifying the input language.

Resolves #1.